### PR TITLE
chore: upgrade chat version 1.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -178,9 +178,9 @@
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
     "@empirica/chat": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@empirica/chat/-/chat-1.1.2.tgz",
-      "integrity": "sha512-8O6ikFJQSJnkmM0CiEDnS4mIsK7jM2Ic5EmHEz1nWO5HC1mDEGrCNxoJt1QEX5erYIJgbo7VDaMYAUufThnMAA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@empirica/chat/-/chat-1.1.3.tgz",
+      "integrity": "sha512-peHnqadzce5dxApTEgNQiwx+R9aNAPwqHeDgKmBlAGfrNf2tBQ1Hsd61726ZygqcrWoe7l5N1p/7n83BChQwRw==",
       "requires": {
         "prop-types": "^15.7.2",
         "react": "^16.5.2"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@babel/runtime": "^7.8.4",
     "@blueprintjs/core": "^3.23.1",
-    "@empirica/chat": "^1.1.2",
+    "@empirica/chat": "^1.1.3",
     "bcrypt": "^3.0.8",
     "fibers": "^5.0.0",
     "grpc": "^1.24.2",


### PR DESCRIPTION
### Chores

This upgraded version of `empirica/chat` will fix your previous issue of `LobbyChat`